### PR TITLE
Make links in show ListenConfig clickable

### DIFF
--- a/src/Snap/Http/Server/Config.hs
+++ b/src/Snap/Http/Server/Config.hs
@@ -69,10 +69,10 @@ data ConfigListen = ListenHttp  ByteString Int
 
 
 instance Show ConfigListen where
-    show (ListenHttp b p) = "http(" ++ show b ++ ":" ++ show p ++ ")"
-    show (ListenHttps b p c k) = "https(" ++ show b ++ ":" ++ show p ++
-                                     ", cert = " ++ show c ++
-                                     ", key = " ++ show k ++ ")"
+    show (ListenHttp b p) = "http://" ++ U.toString b ++ ":" ++ show p
+    show (ListenHttps b p c k) =
+        "https://" ++ U.toString b ++ ":" ++ show p ++
+        " (cert = " ++ show c ++ ", key = " ++ show k ++ ")"
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
When the developer launches the webapp he used see something like

```
Listening on http("0.0.0.0", 8000)
```

I find it more useful when the link is actually clickable, so the developer can just click the link instead of manually navigating to the address.

Cheers,
Jasper
