### PR TITLE
Include cookies in rspHeaders,  in addition to rspCookies

### DIFF
--- a/src/Snap/Internal/Http/Server.hs
+++ b/src/Snap/Internal/Http/Server.hs
@@ -776,7 +776,7 @@ sendResponse req rsp' buffer writeEnd' onSendFile = do
       where
         f h = if null cookies
                 then h
-                else Map.insert "Set-Cookie" cookies h
+                else Map.insertWith (flip (++)) "Set-Cookie" cookies h
         cookies = fmap cookieToBS . Map.elems $ rspCookies r
 
 


### PR DESCRIPTION
I kind of need this change because I have a custom "addHttpCookie" that sets a cookie with the httponly option set,  which is supposed to isolate the cookie from JavaScript.

There are also a number of other options that cookies support,  as either an official or de-facto standard,  that we don't support through our standard Cookie interface.    We should probably do something about this issue;  but this particular change avoids API changes for now as well as preserves the old interface.    It does feel slightly hackish, though.
