### PR TITLE
A simple patch to support semicolon-delimeted parameters in query strings

### DIFF
--- a/src/Snap/Internal/Http/Parser.hs
+++ b/src/Snap/Internal/Http/Parser.hs
@@ -264,7 +264,7 @@ parseUrlEncoded s = foldl' (\m (k,v) -> Map.insertWith' (++) k [v] m)
     breakApart = (second (S.drop 1)) . S.break (== '=')
 
     parts :: [(ByteString,ByteString)]
-    parts = map breakApart $ S.split '&' s
+    parts = map breakApart $ S.splitWith (\c -> c == '&' || c == ';') s
 
     urldecode = parseToCompletion pUrlEscaped
 

--- a/test/suite/Snap/Internal/Http/Parser/Tests.hs
+++ b/test/suite/Snap/Internal/Http/Parser/Tests.hs
@@ -150,7 +150,7 @@ testCookie =
 
 testFormEncoded :: Test
 testFormEncoded = testCase "parser/formEncoded" $ do
-    let bs = "foo1=bar1&foo2=bar2+baz2&foo3=foo%20bar"
+    let bs = "foo1=bar1&foo2=bar2+baz2;foo3=foo%20bar"
     let mp = parseUrlEncoded bs
 
     assertEqual "foo1" (Just ["bar1"]     ) $ Map.lookup "foo1" mp


### PR DESCRIPTION
- Support semicolon-separated query parameters (?a=x;b=y) in addition to ampersand-separated query parameters (?a=x&b=y).

c.f.:  http://www.w3.org/TR/1999/REC-html401-19991224/appendix/notes.html#h-B.2.2
