### PR TITLE
Extend version requirement for `case-insensitive` to allow 0.3.*

### DIFF
--- a/snap-server.cabal
+++ b/snap-server.cabal
@@ -108,7 +108,7 @@ Library
     blaze-builder-enumerator >= 0.2.0 && <0.3,
     bytestring,
     bytestring-nums,
-    case-insensitive >= 0.2 && < 0.3,
+    case-insensitive >= 0.2 && < 0.4,
     containers,
     directory-tree,
     enumerator >= 0.4.13.1 && <0.5,


### PR DESCRIPTION
See also corresponding commit
https://github.com/snapframework/snap-core/commit/56498e84ee04d5cf44576dc4a568d9820c4b5c3d
