### PR TITLE
Fix build with GHC 7.3+

### DIFF
--- a/snap-server.cabal
+++ b/snap-server.cabal
@@ -1,5 +1,5 @@
 name:           snap-server
-version:        0.6.0.1
+version:        0.6.0.2
 synopsis:       A fast, iteratee-based, epoll-enabled web server for the Snap Framework
 description:
   Snap is a simple and fast web development framework and server written in

--- a/src/System/SendFile/Darwin.hsc
+++ b/src/System/SendFile/Darwin.hsc
@@ -1,14 +1,22 @@
-{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE CPP, ForeignFunctionInterface #-}
 -- | Darwin system-dependent code for 'sendfile'.
 module System.SendFile.Darwin (sendFile) where
 
 import Data.Int
 import Foreign.C.Error (eAGAIN, eINTR, getErrno, throwErrno)
+#if __GLASGOW_HASKELL__ >= 703
+import Foreign.C.Types (CInt(CInt))
+#else
 import Foreign.C.Types (CInt)
+#endif
 import Foreign.Marshal (alloca)
 import Foreign.Ptr (Ptr, nullPtr)
 import Foreign.Storable (peek, poke)
+#if __GLASGOW_HASKELL__ >= 703
+import System.Posix.Types (Fd(Fd), COff(COff))
+#else
 import System.Posix.Types (Fd, COff)
+#endif
 
 sendFile :: IO () -> Fd -> Fd -> Int64 -> Int64 -> IO Int64
 sendFile onBlock out_fd in_fd off count


### PR DESCRIPTION
Caused by a GHC change to the semantics of newtypes and FFI imports.
