### PR TITLE
Widen depedency on template-haskell

### DIFF
--- a/snap-server.cabal
+++ b/snap-server.cabal
@@ -119,7 +119,7 @@ Library
     network                   >= 2.3      && < 2.4,
     old-locale,
     snap-core                 >= 0.7      && < 0.8,
-    template-haskell          >= 2.2      && < 2.7,
+    template-haskell          >= 2.2      && < 2.8,
     text                      >= 0.11     && < 0.12,
     time                      >= 1.0      && < 1.5,
     transformers              >= 0.2      && < 0.3,


### PR DESCRIPTION
This is required for snap-server and aeson to co-exist in 7.4.
