### PR TITLE
Catch abrupt SSL connection termination

### DIFF
--- a/src/Snap/Internal/Http/Server/TLS.hs
+++ b/src/Snap/Internal/Http/Server/TLS.hs
@@ -175,10 +175,13 @@ send tickleTimeout _ (NetworkSession _ aSSL sz) bs = go bs
 
 ------------------------------------------------------------------------------
 recv :: IO b -> NetworkSession -> IO (Maybe ByteString)
-recv _ (NetworkSession _ aSSL recvLen) = do
+recv _ (NetworkSession _ aSSL recvLen) = handle termination $ do
     b <- SSL.read ssl recvLen
     return $! if S.null b then Nothing else Just b
   where
     ssl = unsafeCoerce aSSL
+
+    termination :: ConnectionAbruptlyTerminated -> IO (Maybe ByteString)
+    termination = const $ return Nothing
 
 #endif


### PR DESCRIPTION
I decided to handle this through a pull request because there might be some discussion.

This is mostly related to WebSockets and other long-living connections over SSL. When the user closes the browser, the `HsOpenSSL` library throws a `ConnectionAbruptlyTerminated`. Without this patch, this exception bubbles up to the thread handling the connection, which is then killed. This is obviously a bad thing for handlers which still need to do some cleanup work after the connection is closed (e.g. the WebSockets library).
