### PR TITLE
Fixed timeout bug when reading message body

### DIFF
--- a/src/Snap/Internal/Http/Server/SimpleBackend.hs
+++ b/src/Snap/Internal/Http/Server/SimpleBackend.hs
@@ -120,7 +120,7 @@ acceptThread defaultTimeout handler tmgr elog cpu sock exitMVar =
 
     go = runSession defaultTimeout handler tmgr sock
 
-    acceptHandler = 
+    acceptHandler =
         [ Handler $ \(e :: AsyncException) -> throwIO e
         , Handler $ \(e :: SomeException) -> do
               elog $ S.concat [ "SimpleBackend.acceptThread: accept threw: "
@@ -160,7 +160,6 @@ runSession defaultTimeout handler tmgr lsock sock addr = do
     let sinfo = SessionInfo lhost lport rhost rport $ Listen.isSecure lsock
 
     timeoutHandle <- TM.register (killThread curId) tmgr
-    let setTimeout = TM.set timeoutHandle
     let tickleTimeout = TM.tickle timeoutHandle
 
     bracket (Listen.createSession lsock 8192 fd
@@ -182,7 +181,7 @@ runSession defaultTimeout handler tmgr lsock sock addr = do
                               writeEnd
                               (sendFile lsock (tickleTimeout defaultTimeout)
                                         fd writeEnd)
-                              setTimeout
+                              tickleTimeout
             )
 
 


### PR DESCRIPTION
In `Snap.Internal.Types` there's this function:

``` haskell
runRequestBody iter = do
    bumpTimeout <- liftM ($ 5) getTimeoutAction
    ...
```

However instead of bumping (tickle) the timeout with 5 seconds, bumpTimeout will actually incorrectly hard set it to 5 second.

I solved this bug together with @Lemmih.
