### PR TITLE
Relaxed constrain on tls in test.cabal

### DIFF
--- a/test/snap-server-testsuite.cabal
+++ b/test/snap-server-testsuite.cabal
@@ -45,7 +45,7 @@ Executable testsuite
     test-framework-quickcheck2 >= 0.2.12.1 && <0.3,
     text                       >= 0.11     && <0.12,
     time,
-    tls                        >= 0.8.2    && <0.9.2,
+    tls                        >= 0.8.2    && <0.9.3,
     tls-extra                  >= 0.4      && <0.4.5,
     transformers
 
@@ -207,5 +207,5 @@ Executable benchmark
     base >= 4 && < 5,
     network == 2.3.*,
     http-enumerator >= 0.7.1.6 && <0.8,
-    tls >= 0.8.2 && <0.9.2,
+    tls >= 0.8.2 && <0.9.3,
     criterion >= 0.6 && <0.7


### PR DESCRIPTION
Tested in a clean environment (sanboxed).
With tls 0.9.2 every dependency successfully installs, all tests pass.
