### PR TITLE
Bug found in receiveRequest (parseHost)

### DIFF
--- a/src/Snap/Internal/Http/Server.hs
+++ b/src/Snap/Internal/Http/Server.hs
@@ -707,7 +707,7 @@ receiveRequest writeEnd = do
 
         parseHost h = (a, unsafeFromInt (S.drop 1 b))
           where
-            (a,b) = S.break (== (c2w ':')) h
+            (a,b) = S.breakEnd (== (c2w ':')) h
 
         params          = parseUrlEncoded queryString
 


### PR DESCRIPTION
I found a bug in the host address parsing code. It's choking on an ipv6 address. I assumed since the code always expects a ':port' that changing it break from the right would be sufficient.
Bug goes away for me.
