### PR TITLE
To build with ghc7.7 case insensitive needs bumpage.

### DIFF
--- a/snap-server.cabal
+++ b/snap-server.cabal
@@ -91,7 +91,7 @@ Library
     blaze-builder             >= 0.2.1.4  && < 0.4,
     blaze-builder-enumerator  >= 0.2.0    && < 0.3,
     bytestring                >= 0.9.1    && < 0.11,
-    case-insensitive          >= 0.3      && < 1.1,
+    case-insensitive          >= 0.3      && < 1.2,
     containers                >= 0.3      && < 0.6,
     enumerator                >= 0.4.15   && < 0.5,
     MonadCatchIO-transformers >= 0.2.1    && < 0.4,


### PR DESCRIPTION
Easy fix - any reason not to do this?
