### PR TITLE
Export getOther to fix a build break in snap-1.0

### DIFF
--- a/src/Snap/Http/Server.hs
+++ b/src/Snap/Http/Server.hs
@@ -46,7 +46,7 @@ import qualified Snap.Types.Headers                as H
 import           Snap.Util.GZip                    (withCompression)
 import           Snap.Util.Proxy                   (behindProxy)
 import qualified Paths_snap_server                 as V
-import           Snap.Http.Server.Config           (Config, ConfigLog (..), commandLineConfig, completeConfig, defaultConfig, getAccessLog, getBind, getCompression, getDefaultTimeout, getErrorHandler, getErrorLog, getHostname, getLocale, getPort, getProxyType, getSSLBind, getSSLPort, getStartupHook, getVerbose)
+import           Snap.Http.Server.Config           (Config, ConfigLog (..), commandLineConfig, completeConfig, defaultConfig, getAccessLog, getBind, getCompression, getDefaultTimeout, getErrorHandler, getErrorLog, getHostname, getLocale, getOther, getPort, getProxyType, getSSLBind, getSSLPort, getStartupHook, getVerbose)
 import qualified Snap.Http.Server.Types            as Ty
 import           Snap.Internal.Http.Server.Config  (emptyStartupInfo, setStartupConfig, setStartupSockets)
 import           Snap.Internal.Http.Server.Session (httpAcceptLoop, snapToServerHandler)


### PR DESCRIPTION
Fixes the following build break:

Preprocessing library snap-1.0.0.0...
[16 of 33] Compiling Snap.Snaplet.Internal.Initializer ( src/Snap/Snaplet/Internal/Initializer.hs, dist/dist-sandbox-e9cec135/build/Snap/Snaplet/Internal/Initializer.o )

src/Snap/Snaplet/Internal/Initializer.hs:62:48:
    Module `Snap.Http.Server' does not export`getOther'
Failed to install snap-1.0.0.0
cabal: Error: some packages failed to install:
