### PR TITLE
Fix getAddrInfo on DragonflyBSD by adding addrSocketType hint.

### DIFF
--- a/snap-server.cabal
+++ b/snap-server.cabal
@@ -1,5 +1,5 @@
 name:           snap-server
-version:        0.9.5.0
+version:        0.9.5.1
 synopsis:       A fast, iteratee-based, epoll-enabled web server for the Snap Framework
 description:
   Snap is a simple and fast web development framework and server written in

--- a/src/Snap/Internal/Http/Server/Address.hs
+++ b/src/Snap/Internal/Http/Server/Address.hs
@@ -55,7 +55,8 @@ getSockAddr p s | s == "::" =
                               , SockAddrInet6 (fromIntegral p) 0 iN6ADDR_ANY 0
                               )
 getSockAddr p s = do
-    let hints = defaultHints { addrFlags = [AI_NUMERICSERV] }
+    let hints = defaultHints { addrFlags = [AI_NUMERICSERV]
+                             , addrSocketType = Stream }
     ais <- getAddrInfo (Just hints) (Just $ map w2c $ S.unpack s)
                        (Just $ show p)
     if null ais


### PR DESCRIPTION
Fixes this: https://github.com/snapframework/snap-server/issues/56

It runs on dragonfly, but unfortunately I can't get the test suite to build, even in a sandbox:

```
cabal: Could not resolve dependencies:
trying: snap-server-testsuite-0.1.1 (user goal)
next goal: criterion (dependency of snap-server-testsuite-0.1.1)
rejecting: criterion-1.1.0.0, 1.0.2.0, 1.0.1.0, 1.0.0.2, 1.0.0.1, 1.0.0.0
(conflict: snap-server-testsuite => criterion>=0.8 && <0.9)
trying: criterion-0.8.1.0
trying: aeson-0.8.0.2 (dependency of criterion-0.8.1.0)
next goal: tls-extra (dependency of snap-server-testsuite-0.1.1)
rejecting: tls-extra-0.6.6, 0.6.5, 0.6.4, 0.6.3, 0.6.1, 0.6.0 (conflict:
snap-server-testsuite => tls-extra>=0.5 && <0.6)
trying: tls-extra-0.5.1
next goal: text (dependency of snap-server-testsuite-0.1.1)
rejecting: text-1.2.0.4, 1.2.0.3, 1.2.0.2, 1.2.0.0 (conflict:
snap-server-testsuite => text>=0.11 && <1.2)
rejecting: text-1.1.1.3, 1.1.1.2, 1.1.1.1, 1.1.1.0 (conflict: tls-extra =>
text>=0.5 && <1.0)
rejecting: text-1.1.0.1, 1.1.0.0, 1.0.0.1, 1.0.0.0, 0.11.3.1, 0.11.3.0,
0.11.2.3, 0.11.2.2, 0.11.2.1, 0.11.2.0, 0.11.1.13, 0.11.1.12, 0.11.1.11,
0.11.1.10, 0.11.1.9, 0.11.1.8, 0.11.1.7, 0.11.1.6, 0.11.1.5, 0.11.1.3,
0.11.1.2, 0.11.1.1, 0.11.1.0, 0.11.0.8, 0.11.0.7, 0.11.0.6, 0.11.0.5,
0.11.0.4, 0.11.0.3, 0.11.0.2, 0.11.0.1, 0.11.0.0 (conflict: aeson =>
text>=1.1.1.0)
rejecting: text-0.10.0.2, 0.10.0.1, 0.10.0.0, 0.9.1.0, 0.9.0.1, 0.9.0.0,
0.8.1.0, 0.8.0.0, 0.7.2.1, 0.7.1.0, 0.7.0.1, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1
(conflict: snap-server-testsuite => text>=0.11 && <1.2)
Backjump limit reached (change with --max-backjumps).
```