### PR TITLE
Unix socket support implementation

### DIFF
--- a/snap-server.cabal
+++ b/snap-server.cabal
@@ -204,6 +204,7 @@ Test-suite testsuite
     clock                               >= 0.4.1    && < 0.5,
     containers                          >= 0.3      && < 0.6,
     directory                           >= 1.0      && < 1.3,
+    filepath                            >= 1.1      && < 2.0,
     io-streams                          >= 1.3      && < 1.4,
     io-streams-haproxy                  >= 1.0      && < 1.1,
     lifted-base                         >= 0.1      && < 0.3,
@@ -257,7 +258,7 @@ Test-suite testsuite
                    openssl-streams >= 1.1    && < 1.3
 
   if os(linux) && !flag(portable)
-    cpp-options: -DLINUX -DHAS_SENDFILE
+    cpp-options: -DLINUX -DHAS_SENDFILE -DHAS_UNIX_SOCKETS
     other-modules:
       System.SendFile,
       System.SendFile.Linux,
@@ -266,7 +267,7 @@ Test-suite testsuite
 
 
   if os(darwin) && !flag(portable)
-    cpp-options: -DOSX -DHAS_SENDFILE
+    cpp-options: -DOSX -DHAS_SENDFILE -DHAS_UNIX_SOCKETS
     other-modules:
       System.SendFile,
       System.SendFile.Darwin,
@@ -274,7 +275,7 @@ Test-suite testsuite
     c-sources: test/cbits/errno_util.c
 
   if os(freebsd) && !flag(portable)
-    cpp-options: -DFREEBSD -DHAS_SENDFILE
+    cpp-options: -DFREEBSD -DHAS_SENDFILE -DHAS_UNIX_SOCKETS
     other-modules:
       System.SendFile,
       System.SendFile.FreeBSD,
@@ -359,19 +360,19 @@ Executable snap-test-pong-server
     build-depends: unix                         < 2.8
 
   if os(linux) && !flag(portable)
-    cpp-options: -DLINUX -DHAS_SENDFILE
+    cpp-options: -DLINUX -DHAS_SENDFILE -DHAS_UNIX_SOCKETS
     other-modules:
       System.SendFile,
       System.SendFile.Linux
 
   if os(darwin) && !flag(portable)
-    cpp-options: -DOSX -DHAS_SENDFILE
+    cpp-options: -DOSX -DHAS_SENDFILE -DHAS_UNIX_SOCKETS
     other-modules:
       System.SendFile,
       System.SendFile.Darwin
 
   if os(freebsd) && !flag(portable)
-    cpp-options: -DFREEBSD -DHAS_SENDFILE
+    cpp-options: -DFREEBSD -DHAS_SENDFILE -DHAS_UNIX_SOCKETS
     other-modules:
       System.SendFile,
       System.SendFile.FreeBSD
@@ -456,19 +457,19 @@ Executable snap-test-server
     build-depends: unix < 2.8
 
   if os(linux) && !flag(portable)
-    cpp-options: -DLINUX -DHAS_SENDFILE
+    cpp-options: -DLINUX -DHAS_SENDFILE -DHAS_UNIX_SOCKETS
     other-modules:
       System.SendFile,
       System.SendFile.Linux
 
   if os(darwin) && !flag(portable)
-    cpp-options: -DOSX -DHAS_SENDFILE
+    cpp-options: -DOSX -DHAS_SENDFILE -DHAS_UNIX_SOCKETS
     other-modules:
       System.SendFile,
       System.SendFile.Darwin
 
   if os(freebsd) && !flag(portable)
-    cpp-options: -DFREEBSD -DHAS_SENDFILE
+    cpp-options: -DFREEBSD -DHAS_SENDFILE -DHAS_UNIX_SOCKETS
     other-modules:
       System.SendFile,
       System.SendFile.FreeBSD

--- a/snap-server.cabal
+++ b/snap-server.cabal
@@ -130,19 +130,19 @@ Library
                    openssl-streams >= 1.1    && < 1.3
 
   if os(linux) && !flag(portable)
-    cpp-options: -DLINUX -DHAS_SENDFILE
+    cpp-options: -DLINUX -DHAS_SENDFILE -DHAS_UNIX_SOCKETS
     other-modules:
       System.SendFile,
       System.SendFile.Linux
 
   if os(darwin) && !flag(portable)
-    cpp-options: -DOSX -DHAS_SENDFILE
+    cpp-options: -DOSX -DHAS_SENDFILE -DHAS_UNIX_SOCKETS
     other-modules:
       System.SendFile,
       System.SendFile.Darwin
 
   if os(freebsd) && !flag(portable)
-    cpp-options: -DFREEBSD -DHAS_SENDFILE
+    cpp-options: -DFREEBSD -DHAS_SENDFILE -DHAS_UNIX_SOCKETS
     other-modules:
       System.SendFile,
       System.SendFile.FreeBSD

--- a/snap-server.cabal
+++ b/snap-server.cabal
@@ -93,6 +93,7 @@ Library
     case-insensitive                    >= 1.1      && < 1.3,
     clock                               >= 0.4.1    && < 0.5,
     containers                          >= 0.3      && < 0.6,
+    filepath                            >= 1.1      && < 2.0,
     io-streams                          >= 1.3      && < 1.4,
     io-streams-haproxy                  >= 1.0      && < 1.1,
     lifted-base                         >= 0.1      && < 0.3,

--- a/src/Snap/Http/Server/Config.hs
+++ b/src/Snap/Http/Server/Config.hs
@@ -34,6 +34,7 @@ module Snap.Http.Server.Config
   , getSSLPort
   , getVerbose
   , getStartupHook
+  , getUnixSocketAccessMode
 
   , setAccessLog
   , setBind
@@ -52,6 +53,8 @@ module Snap.Http.Server.Config
   , setSSLChainCert
   , setSSLPort
   , setVerbose
+  , setUnixSocketAccessMode
+
   , setStartupHook
   , StartupInfo
   , getStartupSockets

--- a/src/Snap/Http/Server/Config.hs
+++ b/src/Snap/Http/Server/Config.hs
@@ -34,6 +34,7 @@ module Snap.Http.Server.Config
   , getSSLPort
   , getVerbose
   , getStartupHook
+  , getUnixSocket
   , getUnixSocketAccessMode
 
   , setAccessLog
@@ -53,6 +54,7 @@ module Snap.Http.Server.Config
   , setSSLChainCert
   , setSSLPort
   , setVerbose
+  , setUnixSocket
   , setUnixSocketAccessMode
 
   , setStartupHook

--- a/src/Snap/Internal/Http/Server/Address.hs
+++ b/src/Snap/Internal/Http/Server/Address.hs
@@ -18,6 +18,8 @@ import           Control.Monad         (liftM)
 import           Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as S
 import           Data.Maybe            (fromMaybe)
+import qualified Data.Text             as T
+import qualified Data.Text.Encoding    as T
 import           Data.Typeable         (Typeable)
 import           Network.Socket        (AddrInfo (addrAddress, addrFamily, addrSocketType, addrFlags), AddrInfoFlag (AI_NUMERICSERV), Family (AF_INET, AF_INET6), HostName, NameInfoFlag (NI_NUMERICHOST), ServiceName, SockAddr (SockAddrInet, SockAddrInet6, SockAddrUnix), SocketType (Stream), defaultHints, getAddrInfo, getNameInfo, iN6ADDR_ANY, iNADDR_ANY)
 
@@ -59,8 +61,7 @@ getAddressImpl !_getHostAddr addr =
   case addr of
     SockAddrInet p _ -> host (fromIntegral p)
     SockAddrInet6 p _ _ _ -> host (fromIntegral p)
-    SockAddrUnix path -> return (-1, S.pack $ "unix:" ++ path)
-    --x -> throwIO $ AddressNotSupportedException $ show x
+    SockAddrUnix path -> return (-1, T.encodeUtf8 . T.pack $ "unix:" ++ path)
   where
     host port = (,) port . S.pack <$> _getHostAddr addr
 ------------------------------------------------------------------------------

--- a/src/Snap/Internal/Http/Server/Address.hs
+++ b/src/Snap/Internal/Http/Server/Address.hs
@@ -19,7 +19,7 @@ import           Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as S
 import           Data.Maybe            (fromMaybe)
 import           Data.Typeable         (Typeable)
-import           Network.Socket        (AddrInfo (addrAddress, addrFamily, addrSocketType, addrFlags), AddrInfoFlag (AI_NUMERICSERV), Family (AF_INET, AF_INET6), HostName, NameInfoFlag (NI_NUMERICHOST), ServiceName, SockAddr (SockAddrInet, SockAddrInet6), SocketType (Stream), defaultHints, getAddrInfo, getNameInfo, iN6ADDR_ANY, iNADDR_ANY)
+import           Network.Socket        (AddrInfo (addrAddress, addrFamily, addrSocketType, addrFlags), AddrInfoFlag (AI_NUMERICSERV), Family (AF_INET, AF_INET6), HostName, NameInfoFlag (NI_NUMERICHOST), ServiceName, SockAddr (SockAddrInet, SockAddrInet6, SockAddrUnix), SocketType (Stream), defaultHints, getAddrInfo, getNameInfo, iN6ADDR_ANY, iNADDR_ANY)
 
 
 ------------------------------------------------------------------------------
@@ -55,14 +55,14 @@ getAddress = getAddressImpl getHostAddr
 
 ------------------------------------------------------------------------------
 getAddressImpl :: (SockAddr -> IO String) -> SockAddr -> IO (Int, ByteString)
-getAddressImpl !_getHostAddr addr = do
-    port <- case addr of
-              SockAddrInet p _ -> return p
-              SockAddrInet6 p _ _ _ -> return p
-              x -> throwIO $ AddressNotSupportedException $ show x
-    host <- _getHostAddr addr
-    return (fromIntegral port, S.pack host)
-
+getAddressImpl !_getHostAddr addr =
+  case addr of
+    SockAddrInet p _ -> host (fromIntegral p)
+    SockAddrInet6 p _ _ _ -> host (fromIntegral p)
+    SockAddrUnix path -> return (-1, S.pack $ "unix:" ++ path)
+    --x -> throwIO $ AddressNotSupportedException $ show x
+  where
+    host port = (,) port . S.pack <$> _getHostAddr addr
 ------------------------------------------------------------------------------
 getSockAddr :: Int
             -> ByteString

--- a/src/Snap/Internal/Http/Server/Config.hs
+++ b/src/Snap/Internal/Http/Server/Config.hs
@@ -410,15 +410,15 @@ getUnixSocket     :: Config m a -> Maybe FilePath
 getUnixSocket = unixsocket
 
 -- | Access mode for unix socket, by default is system specific.
---  This should only be used to grant additional permissions to created
---  socket file, and not to remove permissions set by default. The only portable way
---  to limit access to socket is creating it in a directory with proper permissions
---  set.
+-- This should only be used to grant additional permissions to created
+-- socket file, and not to remove permissions set by default.
+-- The only portable way to limit access to socket is creating it in a
+-- directory with proper permissions set.
 --
---  Most BSD systems ignore access permissionse on sockets.
+-- Most BSD systems ignore access permissions on unix sockets.
 --
---  Note: This uses umask. There is a race condition if process creates other
---  files at the same time as opening a unix socket with this option set.
+-- Note: This uses umask. There is a race condition if process creates other
+-- files at the same time as opening a unix socket with this option set.
 getUnixSocketAccessMode :: Config m a -> Maybe Int
 getUnixSocketAccessMode = unixaccessmode
 

--- a/src/Snap/Internal/Http/Server/Config.hs
+++ b/src/Snap/Internal/Http/Server/Config.hs
@@ -404,11 +404,21 @@ getSSLChainCert = sslchaincert
 getSSLKey         :: Config m a -> Maybe FilePath
 getSSLKey = sslkey
 
--- | File path to unix socket. Must be absolute.
+-- | File path to unix socket. Must be absolute path, but allows for symbolic
+-- links.
 getUnixSocket     :: Config m a -> Maybe FilePath
 getUnixSocket = unixsocket
 
 -- | Access mode for unix socket, by default is system specific.
+--  This should only be used to grant additional permissions to created
+--  socket file, and not to remove permissions set by default. The only portable way
+--  to limit access to socket is creating it in a directory with proper permissions
+--  set.
+--
+--  Most BSD systems ignore access permissionse on sockets.
+--
+--  Note: This uses umask. There is a race condition if process creates other
+--  files at the same time as opening a unix socket with this option set.
 getUnixSocketAccessMode :: Config m a -> Maybe Int
 getUnixSocketAccessMode = unixaccessmode
 

--- a/src/Snap/Internal/Http/Server/Socket.hs
+++ b/src/Snap/Internal/Http/Server/Socket.hs
@@ -72,7 +72,9 @@ bindUnixSocket :: Maybe Int -> String -> IO Socket
 #if HAS_UNIX_SOCKETS
 bindUnixSocket mode path = do
    when (isRelative path) $
-      throwIO (AddressNotSupportedException path)
+      throwIO $ AddressNotSupportedException
+                $! "Refusing to bind unix socket to non-absolute path: " ++ path
+
    bracketOnError (socket N.AF_UNIX N.Stream 0) N.close $ \sock -> do
       catch (removeLink path) $ \e -> when (not $ isDoesNotExistError e) $ throwIO e
       case mode of

--- a/test/Snap/Internal/Http/Server/Address/Tests.hs
+++ b/test/Snap/Internal/Http/Server/Address/Tests.hs
@@ -17,7 +17,7 @@ import           Snap.Test.Common                  (coverShowInstance, coverType
 ------------------------------------------------------------------------------
 tests :: [Test]
 tests = [ testGetNameInfoFails
-        , testGetAddressBadType
+        , testGetAddressUnix
         , testGetAddressIPv6
         , testGetSockAddr
         , testTrivials
@@ -32,9 +32,11 @@ testGetNameInfoFails = testCase "address/getNameInfo-fails" $ do
 
 
 ------------------------------------------------------------------------------
-testGetAddressBadType :: Test
-testGetAddressBadType = testCase "address/getAddress-bad-type" $
-    expectException $ getAddress $ SockAddrUnix "foo"
+testGetAddressUnix :: Test
+testGetAddressUnix = testCase "address/getAddress-unix-socket" $ do
+    (port, addr) <- getAddress $ SockAddrUnix "/foo/bar"
+    assertEqual "unix port" (-1) port
+    assertEqual "unix address" "unix:/foo/bar" addr
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
This is not yet ready to be merged.
Tests and documentation are missing. But I think this PR can be used
as a starting point for implementation and discussion.

To use unix sockets specify "unix:/abs/path.sock" as address in config.
It is probably better to use separate parameter unix socket
specification. Server then can listen on http, https and unix sockets at
the same time.

Setting access permissions on socket is important if your snap server
and proxy, like nginx, are run with different users. So you can set
group write permission and add nginx user to same group as snap server.

On command line access rights are specified in octal.

Permissions are set with umask, so there is a race condition because
umask is process wide shared attribute. Setting permissions using
setFilePermissions can lead to race conditions if socket file is renamed
or unlinked while program is running.
In theory on Linux at least you can set permissions for socket Fd before
binding, but in my case it was setting not all permissions. Possibly
because it is also affected by umask set somewhere else.

Checking for HAS_SENDFILE, because it is defined on *nixes.

Using abs path only is a security feature, and is often recommended, for
example in TLPI.