### PR TITLE
Issue/62 custom access and error log handlers

### DIFF
--- a/src/Snap/Http/Server.hs
+++ b/src/Snap/Http/Server.hs
@@ -77,7 +77,9 @@ simpleHttpServe config handler = do
                           (listeners conf)
                           (fromJust $ getHostname  conf)
                           alog
+                          (getAccessLogHandler conf)
                           elog
+                          (getErrorLogHandler conf)
                           (\sockets -> let dat = mkStartupInfo sockets conf
                                        in maybe (return ())
                                                 ($ dat)

--- a/src/Snap/Http/Server/Config.hs
+++ b/src/Snap/Http/Server/Config.hs
@@ -9,6 +9,9 @@ module Snap.Http.Server.Config
   ( Config
   , ConfigLog(..)
 
+  , AccessLogHandler
+  , ErrorLogHandler
+
   , emptyConfig
   , defaultConfig
   , commandLineConfig
@@ -65,3 +68,4 @@ module Snap.Http.Server.Config
   ) where
 
 import Snap.Internal.Http.Server.Config
+import Snap.Internal.Http.Server

--- a/src/Snap/Http/Server/Config.hs
+++ b/src/Snap/Http/Server/Config.hs
@@ -19,11 +19,13 @@ module Snap.Http.Server.Config
   , fmapOpt
 
   , getAccessLog
+  , getAccessLogHandler
   , getBind
   , getCompression
   , getDefaultTimeout
   , getErrorHandler
   , getErrorLog
+  , getErrorLogHandler
   , getHostname
   , getLocale
   , getOther
@@ -38,11 +40,13 @@ module Snap.Http.Server.Config
   , getStartupHook
 
   , setAccessLog
+  , setAccessLogHandler
   , setBind
   , setCompression
   , setDefaultTimeout
   , setErrorHandler
   , setErrorLog
+  , setErrorLogHandler
   , setHostname
   , setLocale
   , setOther


### PR DESCRIPTION
Note: This is the first of two pull requests. This is the first one and aims to backport my changes to 0.9-stable. The second one will port these changes to master.

I am trying to solve #62 in this pull request. It is my aim to be able to push out the access and error logs in a custom format: in my case, JSON. You can see an example of me testing this branch and doing that here:

![My Reminders JSON log](https://s3.amazonaws.com/uploads.hipchat.com/10804/83693/PXjauYS0wpoxurf/Screen%20Shot%202015-05-20%20at%206.21.24%20pm.png)

You can see an example of me using this branch in the My Reminders code here: https://bitbucket.org/atlassianlabs/my-reminders/branch/issue/MR-7-json-logs-for-my-reminders#diff

I hope that you like these changes and are willing to accept them. I have spoken to @gregorycollins and he suggested that such a feature would be desirable. I am also open to suggestions on how to improve this PR but I can tell you that it works (via my manual testing) and lightly extends existing behaviour in its current form.