### PR TITLE
304 and 204 responses should have empty bodies

### DIFF
--- a/src/Snap/Internal/Http/Server.hs
+++ b/src/Snap/Internal/Http/Server.hs
@@ -751,7 +751,7 @@ sendResponse req rsp0 buffer writeEnd' onSendFile = do
     --------------------------------------------------------------------------
     noCL :: Response -> (Response, Bool)
     noCL r =
-        if rqMethod req == HEAD
+        if rqMethod req == HEAD || rspStatus r == 304 || rspStatus r == 204
           then let r' = r { rspBody = Enum $ enumBuilder mempty }
                in (r', False)
           else if rspHttpVersion r >= (1,1)


### PR DESCRIPTION
This commit: 
https://github.com/snapframework/snap-core/commit/10f44610f5e597f665de7c3e8d07a70870c97688
removes content length from 304 and 204 responses. This causes snap-server to send the (empty) body using chunked encoding, which ends up sending a single '0' in the response body. This in turn confuses Apache when running as a proxy server, possibly other clients as well.

The proposed solution is to specifically check for 304 and 204 responses in "sendResponse".