### PR TITLE
Fix FreeBSD sendfile

### DIFF
--- a/src/System/SendFile/FreeBSD.hsc
+++ b/src/System/SendFile/FreeBSD.hsc
@@ -12,7 +12,7 @@ module System.SendFile.FreeBSD
 import           Control.Concurrent    (threadWaitWrite)
 import           Data.Int
 import           Data.Word
-import           Foreign.C.Error       (throwErrnoIfMinus1RetryMayBlock)
+import           Foreign.C.Error       (throwErrnoIfMinus1RetryMayBlock_)
 #if __GLASGOW_HASKELL__ >= 703
 import           Foreign.C.Types       (CInt (..), CSize (..))
 #else
@@ -31,6 +31,8 @@ import           System.Posix.Types    (COff, Fd)
 
 ------------------------------------------------------------------------------
 sendFile :: Fd -> Fd -> Word64 -> Word64 -> IO Int64
+sendFile = sendFileImpl c_sendfile_freebsd threadWaitWrite
+{-# INLINE sendFile #-}
 
 
 ------------------------------------------------------------------------------

--- a/test/System/SendFile/Tests.hs
+++ b/test/System/SendFile/Tests.hs
@@ -148,13 +148,13 @@ data SendFileCallLog = SendFileCallLog {
       _sf_fd1 :: Fd
     , _sf_fd2 :: Fd
     , _sf_off :: COff
-    , _sf_sz  :: COff
+    , _sf_sz  :: CSize
     }
   deriving (Eq, Show, Ord)
 
 
 ------------------------------------------------------------------------------
-sendFileMockSendFunc :: MVar [IO CSize]          -- ^ sample outputs
+sendFileMockSendFunc :: MVar [IO CInt]          -- ^ sample outputs
                      -> MVar [SendFileCallLog]   -- ^ log of calls
                      -> Fd -> Fd -> COff -> CSize -> Ptr () -> Ptr COff
                      -> CInt -> IO CInt
@@ -162,8 +162,7 @@ sendFileMockSendFunc sampleData callLog !fd1 !fd2 !off !clen !_ !pbytes !_ = do
     modifyMVar_ callLog (return . (++ [SendFileCallLog fd1 fd2 off clen]))
     x <- modifyMVar sampleData $ \xs -> return $!
             if null xs then ([], return Nothing) else (tail xs, fmap Just $! head xs)
-    x >>= maybe (c_set_errno eCONNRESET >> return (-1))
-                (\l -> poke pbytes (fromIntegral l) >> return 0)
+    x >>= maybe (c_set_errno eCONNRESET >> return (-1)) return
 
 
 #elif defined(OSX)


### PR DESCRIPTION
Tests pass, and tracing syscalls with dtruss shows sendfile being called for successful responses.

Fixes #91