### PR TITLE
Don't listen on default port if unix socket is specified in config.

### DIFF
--- a/src/Snap/Internal/Http/Server/Config.hs
+++ b/src/Snap/Internal/Http/Server/Config.hs
@@ -560,7 +560,8 @@ completeConfig config = do
                           , isJust . getSSLCert ]
 
     sslValid   = and sslVals
-    noPort = isNothing (getPort cfg) && not sslValid
+    unixValid  = isJust $ unixsocket cfg
+    noPort = isNothing (getPort cfg) && not sslValid && not unixValid
 
     cfg' = emptyConfig { port = if noPort then Just 8000 else Nothing }
 


### PR DESCRIPTION
I want my application to listen only on a unix socket, but it wasn't possible to do this as it would also listen on the default port.