### PR TITLE
Allow criterion-1.5

### DIFF
--- a/snap-server.cabal
+++ b/snap-server.cabal
@@ -318,7 +318,7 @@ Benchmark benchmark
     blaze-builder                       >= 0.4     && < 0.5,
     bytestring                          >= 0.9     && < 0.11,
     bytestring-builder                  >= 0.10.4  && < 0.11,
-    criterion                           >= 0.6     && < 1.4,
+    criterion                           >= 0.6     && < 1.5,
     io-streams,
     io-streams-haproxy                  >= 1.0     && < 1.1,
     snap-core                           >= 1.0     && < 1.1,


### PR DESCRIPTION
The differences in the benchmark results look negligible:

With `criterion-1.3.0.0`:
```
benchmarking parser/firefoxget
time                 892.0 μs   (885.7 μs .. 897.2 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 886.5 μs   (883.0 μs .. 890.3 μs)
std dev              12.24 μs   (10.20 μs .. 16.02 μs)
```

With `criterion-1.4.0.0`:
```
benchmarking parser/firefoxget
time                 887.1 μs   (883.9 μs .. 890.6 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 891.5 μs   (887.9 μs .. 897.1 μs)
std dev              15.14 μs   (10.20 μs .. 23.83 μs)
```