### PR TITLE
Add a bug-reports field to the cabal file

### DIFF
--- a/snap-server.cabal
+++ b/snap-server.cabal
@@ -18,6 +18,7 @@ maintainer:     snap@snapframework.com
 build-type:     Simple
 cabal-version:  >= 1.10
 homepage:       http://snapframework.com/
+bug-reports:    https://github.com/snapframework/snap-server/issues
 category:       Web, Snap, IO-Streams
 
 


### PR DESCRIPTION
This creates a clickable link from Hackage to the GitHub repo.