### PR TITLE
 Allow network-2.8.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ cabal.sandbox.config
 result
 test/*.log
 *.log
+.ghc.environment.*

--- a/snap-server.cabal
+++ b/snap-server.cabal
@@ -107,7 +107,7 @@ Library
     io-streams-haproxy                  >= 1.0      && < 1.1,
     lifted-base                         >= 0.1      && < 0.3,
     mtl                                 >= 2.0      && < 2.3,
-    network                             >= 2.3      && < 2.8,
+    network                             >= 2.3      && < 2.9,
     old-locale                          >= 1.0      && < 1.1,
     snap-core                           >= 1.0      && < 1.1,
     text                                >= 0.11     && < 1.3,


### PR DESCRIPTION
The only silently breaking change in `network-2.8` concerns the `Ord` instance for `PortNumber`, which doesn't seem to be used by `snap-server`.