### PR TITLE
Fix TLS compatibility with newest versions of 'network'

### DIFF
--- a/src/Snap/Internal/Http/Server/TLS.hs
+++ b/src/Snap/Internal/Http/Server/TLS.hs
@@ -21,7 +21,7 @@ import           Network.Socket                    (Socket)
 import           Control.Exception                 (Exception, bracketOnError, finally, onException, throwIO)
 import           Control.Monad                     (when)
 import           Data.ByteString.Builder           (byteString)
-import qualified Network.Socket                    as Socket
+import qualified Snap.Internal.Http.Server.Socket  as Socket
 import           OpenSSL                           (withOpenSSL)
 import           OpenSSL.Session                   (SSL, SSLContext)
 import qualified OpenSSL.Session                   as SSL


### PR DESCRIPTION
Fixes this error when installing from Hackage:

```
[19 of 20] Compiling Snap.Internal.Http.Server.TLS ( src/Snap/Internal/Http/Server/TLS.hs, dist/build/Snap/Internal/Http/Server/TLS.o )

src/Snap/Internal/Http/Server/TLS.hs:108:14: error:
    Not in scope: ‘Socket.bindSocket’
    Perhaps you meant one of these:
      ‘Socket.fdSocket’ (imported from Network.Socket),
      ‘Socket.mkSocket’ (imported from Network.Socket)
    Module ‘Network.Socket’ does not export ‘bindSocket’.
    |
108 |              Socket.bindSocket sock addr
    |              ^^^^^^^^^^^^^^^^^
cabal: Failed to build snap-server-1.1.1.1 (which is required by
exe:audm-backend from audm-backend-0.1.0.0). See the build log above for
details.
```

If you could push a release to Hackage with this fix that would be :ok_hand: 