### PR TITLE
Drop CI testing for ghc-7.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,6 @@ matrix:
     - compiler: "ghc-7.8.4"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-7.8.4], sources: [hvr-ghc]}}
-    - compiler: "ghc-7.6.3"
-    # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-7.6.3], sources: [hvr-ghc]}}
 
 before_install:
   - HC=${CC}

--- a/snap-server.cabal
+++ b/snap-server.cabal
@@ -1,5 +1,5 @@
 name:           snap-server
-version:        1.1.1.1
+version:        1.1.1.2
 synopsis:       A web server for the Snap Framework
 description:
   Snap is a simple and fast web development framework and server written in
@@ -34,7 +34,6 @@ extra-source-files:
   testserver/static/hello.txt
 
 tested-with:
-  GHC==7.6.3,
   GHC==7.8.4,
   GHC==7.10.3,
   GHC==8.0.2,


### PR DESCRIPTION
7.6.3 is well outside both the "three major releases" and "three years" support windows.

Let's drop support, to help along PR's like #124?