### PR TITLE
fixed 5 warnings

### DIFF
--- a/snap-server.cabal
+++ b/snap-server.cabal
@@ -507,6 +507,7 @@ Executable snap-test-server
     clock,
     containers,
     directory,
+    filepath,
     io-streams,
     io-streams-haproxy,
     lifted-base,

--- a/src/Snap/Internal/Http/Server/Address.hs
+++ b/src/Snap/Internal/Http/Server/Address.hs
@@ -22,10 +22,8 @@ import           Control.Monad         (liftM)
 import           Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as S
 import           Data.Maybe            (fromMaybe)
-import qualified Data.Text             as T
-import qualified Data.Text.Encoding    as T
 import           Data.Typeable         (Typeable)
-import           Network.Socket        (AddrInfo (addrAddress, addrFamily, addrFlags, addrSocketType), AddrInfoFlag (AI_NUMERICSERV, AI_PASSIVE), Family (AF_INET, AF_INET6), HostName, NameInfoFlag (NI_NUMERICHOST), ServiceName, SockAddr (SockAddrInet, SockAddrInet6, SockAddrUnix), SocketType (Stream), defaultHints, getAddrInfo, getNameInfo)
+import           Network.Socket        (AddrInfo (addrAddress, addrFamily, addrFlags, addrSocketType), AddrInfoFlag (AI_NUMERICSERV, AI_PASSIVE), Family (AF_INET, AF_INET6), HostName, NameInfoFlag (NI_NUMERICHOST), ServiceName, SockAddr (SockAddrInet, SockAddrInet6), SocketType (Stream), defaultHints, getAddrInfo, getNameInfo)
 
 
 ------------------------------------------------------------------------------
@@ -65,13 +63,15 @@ getAddressImpl !_getHostAddr addr =
   case addr of
     SockAddrInet p _      -> host (fromIntegral p)
     SockAddrInet6 p _ _ _ -> host (fromIntegral p)
-    SockAddrUnix path     -> return (-1, prefix path)
 #if MIN_VERSION_network(2,6,0)
     _                     -> fail "Unsupported address type"
+    where
+      host port   = (,) port . S.pack <$> _getHostAddr addr
+#else
+    SockAddrUnix path     -> return (-1, prefix path)
+    where
+      prefix path = T.encodeUtf8 $! T.pack $ "unix:" ++ path
 #endif
-  where
-    prefix path = T.encodeUtf8 $! T.pack $ "unix:" ++ path
-    host port   = (,) port . S.pack <$> _getHostAddr addr
 
 
 ------------------------------------------------------------------------------

--- a/src/Snap/Internal/Http/Server/Session.hs
+++ b/src/Snap/Internal/Http/Server/Session.hs
@@ -35,7 +35,7 @@ import           Data.Maybe                               (fromJust, fromMaybe, 
 #if !MIN_VERSION_base(4,8,0)
 import           Data.Monoid                              (mconcat)
 #endif
-import           Data.Monoid                              ((<>))
+import           Data.Monoid                              ()
 import           Data.Time.Format                         (formatTime)
 import           Data.Typeable                            (Typeable)
 import           Data.Version                             (showVersion)

--- a/src/Snap/Internal/Http/Server/Session.hs
+++ b/src/Snap/Internal/Http/Server/Session.hs
@@ -35,6 +35,9 @@ import           Data.Maybe                               (fromJust, fromMaybe, 
 #if !MIN_VERSION_base(4,8,0)
 import           Data.Monoid                              (mconcat)
 #endif
+#if !MIN_VERSION_base(4,11,0)
+import           Data.Semigroup                           (Semigroup (..))
+#endif
 import           Data.Monoid                              ()
 import           Data.Time.Format                         (formatTime)
 import           Data.Typeable                            (Typeable)

--- a/src/Snap/Internal/Http/Server/Socket.hs
+++ b/src/Snap/Internal/Http/Server/Socket.hs
@@ -21,7 +21,7 @@ import           Data.ByteString.Char8             (ByteString)
 import           Network.Socket                    (Socket, SocketOption (NoDelay, ReuseAddr), accept, close, getSocketName, setSocketOption, socket)
 import qualified Network.Socket                    as N
 #ifdef HAS_SENDFILE
-import           Network.Socket                    (fdSocket)
+import           Network.Socket                    (unsafeFdSocket)
 import           System.Posix.IO                   (OpenMode (..), closeFd, defaultFileFlags, openFd)
 import           System.Posix.Types                (Fd (..))
 import           System.SendFile                   (sendFile, sendHeaders)
@@ -175,7 +175,7 @@ sendFileFunc sock !_ builder fPath offset nbytes = bracket acquire closeFd go
   where
     acquire   = openFd fPath ReadOnly Nothing defaultFileFlags
 #if MIN_VERSION_network(3,0,0)
-    go fileFd = do sockFd <- Fd `fmap` fdSocket sock
+    go fileFd = do sockFd <- Fd `fmap` unsafeFdSocket sock
                    sendHeaders builder sockFd
                    sendFile sockFd fileFd offset nbytes
 #else

--- a/src/Snap/Internal/Http/Server/TLS.hs
+++ b/src/Snap/Internal/Http/Server/TLS.hs
@@ -105,7 +105,7 @@ bindHttps bindAddress bindPort cert chainCert key =
         (Socket.close . fst)
         $ \(sock, addr) -> do
              Socket.setSocketOption sock Socket.ReuseAddr 1
-             Socket.bindSocket sock addr
+             Socket.bind sock addr
              Socket.listen sock 150
 
              ctx <- SSL.context

--- a/test/Paths_snap_server.hs
+++ b/test/Paths_snap_server.hs
@@ -2,7 +2,7 @@ module Paths_snap_server (
     version
   ) where
 
-import           Data.Version (Version (..))
+import           Data.Version (Version, makeVersion)
 
 version :: Version
-version = Version {versionBranch = [0,0,0], versionTags = ["unknown"]}
+version = makeVersion [0,0,0]

--- a/test/Test/Common/TestHandler.hs
+++ b/test/Test/Common/TestHandler.hs
@@ -15,7 +15,7 @@ import qualified Data.ByteString.Lazy.Char8    as L
 import           Data.List                     (sort)
 import qualified Data.Map                      as Map
 import           Data.Maybe                    (fromMaybe)
-import           Data.Monoid                   (Monoid (mappend, mconcat, mempty))
+import           Data.Monoid                   ()
 ------------------------------------------------------------------------------
 import           Snap.Core                     (Request (rqParams, rqURI), Snap, getParam, getRequest, logError, modifyResponse, redirect, route, rqClientAddr, rqClientPort, setContentLength, setContentType, setHeader, setResponseBody, setResponseCode, setTimeout, transformRequestBody, writeBS, writeBuilder, writeLBS)
 import           Snap.Internal.Debug           ()


### PR DESCRIPTION
Compiled with ghc 8.8.3
This request removes the following 5 warnings:

src/Snap/Internal/Http/Server/Address.hs:70:5: warning: [-Woverlapping-patterns]
    Pattern match is redundant
    In a case alternative: _ -> ...
   |
70 |     _                     -> fail "Unsupported address type"
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Snap/Internal/Http/Server/Session.hs:38:1: warning: [-Wunused-imports]
    The import of ‘Data.Monoid’ is redundant
      except perhaps to import instances from ‘Data.Monoid’
    To import instances alone, use: import Data.Monoid()
   |
38 | import           Data.Monoid                              ((<>))
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Snap/Internal/Http/Server/Socket.hs:178:40: warning: [-Wdeprecations]
    In the use of ‘fdSocket’
    (imported from Network.Socket, but defined in network-3.1.1.1:Network.Socket.Types):
    Deprecated: "Use withFdSocket or unsafeFdSocket instead"
    |
178 |     go fileFd = do sockFd <- Fd `fmap` fdSocket sock
    |                                        ^^^^^^^^

src/Snap/Internal/Http/Server/Session.hs:38:1: warning: [-Wunused-imports]
    The import of ‘Data.Monoid’ is redundant
      except perhaps to import instances from ‘Data.Monoid’
    To import instances alone, use: import Data.Monoid()
   |
38 | import           Data.Monoid                              ((<>))
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Snap/Internal/Http/Server/Socket.hs:178:40: warning: [-Wdeprecations]
    In the use of ‘fdSocket’
    (imported from Network.Socket, but defined in network-3.1.1.1:Network.Socket.Types):
    Deprecated: "Use withFdSocket or unsafeFdSocket instead"
    |
178 |     go fileFd = do sockFd <- Fd `fmap` fdSocket sock
    |                                        ^^^^^^^^

