### PR TITLE
HTTP-version related improvements & cleanups

### DIFF
--- a/snap-server.cabal
+++ b/snap-server.cabal
@@ -99,7 +99,7 @@ Library
     attoparsec                          >= 0.12     && < 0.14,
     base                                >= 4.6      && < 4.15,
     blaze-builder                       >= 0.4      && < 0.5,
-    bytestring                          >= 0.9.1    && < 0.11,
+    bytestring                          >= 0.10     && < 0.11,
     bytestring-builder                  >= 0.10.4   && < 0.11,
     case-insensitive                    >= 1.1      && < 1.3,
     clock                               >= 0.7.1    && < 0.9,

--- a/src/Snap/Internal/Http/Server/Session.hs
+++ b/src/Snap/Internal/Http/Server/Session.hs
@@ -495,7 +495,7 @@ httpSession !buffer !serverHandler !config !sessionData = loop
         -- For HTTP/1.0: if there is no explicit Connection: Keep-Alive,
         -- close the socket later.
         let v = CI.mk <$> connection
-        when ((version == (1, 1) && v == Just "close") ||
+        when ((version >= (1, 1) && v == Just "close") ||
               (version == (1, 0) && v /= Just "keep-alive")) $
               writeIORef forceConnectionClose True
 
@@ -659,7 +659,7 @@ httpSession !buffer !serverHandler !config !sessionData = loop
          -> ResponseBody
          -> (Headers, ResponseBody, Bool)
     noCL req hdrs body =
-        if v == (1,1)
+        if v >= (1,1)
           then let origBody = rspBodyToEnum body
                    body'    = \os -> do
                                  os' <- writeChunkedTransferEncoding os
@@ -738,7 +738,7 @@ httpSession !buffer !serverHandler !config !sessionData = loop
 mkHeaderLine :: HttpVersion -> Response -> FixedPrim ()
 mkHeaderLine outVer r =
     case outCode of
-        200 | outVer == (1, 1) ->
+        200 | outVer >= (1, 1) ->
                   -- typo in bytestring here
                   fixedPrim 17 $ const (void . cpBS "HTTP/1.1 200 OK\r\n")
         200 | otherwise ->
@@ -747,7 +747,7 @@ mkHeaderLine outVer r =
   where
     outCode = rspStatus r
 
-    v = if outVer == (1,1) then "HTTP/1.1 " else "HTTP/1.0 "
+    v = if outVer >= (1,1) then "HTTP/1.1 " else "HTTP/1.0 "
 
     outCodeStr = S.pack $ show outCode
     space !op = do


### PR DESCRIPTION
These are a couple of the issues I noticed with the HTTP-version handling in snap-server