### PR TITLE
Allow base16-bytestring 1.0

### DIFF
--- a/snap-server.cabal
+++ b/snap-server.cabal
@@ -214,7 +214,7 @@ Test-suite testsuite
   build-depends:
     attoparsec,
     base,
-    base16-bytestring                   >= 0.1      && < 0.2,
+    base16-bytestring                   >= 0.1      && < 1.1,
     blaze-builder,
     bytestring-builder,
     bytestring,


### PR DESCRIPTION
The testsuite passed for me locally, when built with the new `base16-bytestring` release.

Context: https://github.com/commercialhaskell/stackage/issues/5649