### PR TITLE
Depend on bytestring-builder only on ghc < 7.8

### DIFF
--- a/snap-server.cabal
+++ b/snap-server.cabal
@@ -100,7 +100,6 @@ Library
     base                                >= 4.6      && < 4.15,
     blaze-builder                       >= 0.4      && < 0.5,
     bytestring                          >= 0.9.1    && < 0.11,
-    bytestring-builder                  >= 0.10.4   && < 0.11,
     case-insensitive                    >= 1.1      && < 1.3,
     clock                               >= 0.7.1    && < 0.9,
     containers                          >= 0.3      && < 0.7,
@@ -134,6 +133,9 @@ Library
 
   if !impl(ghc >= 8.0)
     build-depends: semigroups >= 0.16 && < 0.19
+
+  if !impl(ghc >= 7.8)
+    build-depends: bytestring-builder >= 0.10.4 && < 0.11
 
   if flag(portable) || os(windows)
     cpp-options: -DPORTABLE
@@ -216,7 +218,6 @@ Test-suite testsuite
     base,
     base16-bytestring                   >= 0.1      && < 1.1,
     blaze-builder,
-    bytestring-builder,
     bytestring,
     case-insensitive,
     clock,
@@ -265,6 +266,9 @@ Test-suite testsuite
 
   if !impl(ghc >= 8.0)
     build-depends: semigroups
+
+  if !impl(ghc >= 7.8)
+    build-depends: bytestring-builder
 
   if flag(portable) || os(windows)
     cpp-options: -DPORTABLE


### PR DESCRIPTION
It's not needed on newer GHC.