### PR TITLE
Build on GHC 9.2.4

### DIFF
--- a/snap-server.cabal
+++ b/snap-server.cabal
@@ -1,5 +1,5 @@
 name:           snap-server
-version:        1.1.2.0
+version:        1.1.2.1
 synopsis:       A web server for the Snap Framework
 description:
   Snap is a simple and fast web development framework and server written in
@@ -41,7 +41,8 @@ tested-with:
   GHC==8.4.4,
   GHC==8.6.5,
   GHC==8.8.3,
-  GHC==8.10.1
+  GHC==8.10.1,
+  GHC==9.2.4
 
 Flag portable
   Description: Compile in cross-platform mode. No platform-specific code or
@@ -97,7 +98,7 @@ Library
 
   build-depends:
     attoparsec                          >= 0.12     && < 0.15,
-    base                                >= 4.6      && < 4.16,
+    base                                >= 4.6      && < 4.17,
     blaze-builder                       >= 0.4      && < 0.5,
     bytestring                          >= 0.9.1    && < 0.12,
     case-insensitive                    >= 1.1      && < 1.3,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+resolver: nightly-2022-10-06
+packages: 
+- .
+extra-deps:
+- ../readable
+- ../snap-core


### PR DESCRIPTION
Builds on GHC 9.2.4 needing only relaxation of the upper bound on **base** (and bumps to **readable** and **snap-core**).

```
         Properties  Test Cases   Total       
 Passed  4           71           75          
 Failed  0           0            0           
 Total   4           71           75          
```

It'd be really nice if we could get **snap-core** and **snap-server** back into Stackage, but regardless thanks for your ongoing stewardship of these packages. Cheers.

- https://github.com/mightybyte/readable/pull/5
- https://github.com/snapframework/snap-core/pull/321